### PR TITLE
fix/nullref on source discovery

### DIFF
--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -288,7 +288,9 @@ public static class NomadKuboEventStreamHandlerExtensions
                 Guard.IsNotNullOrWhiteSpace(entry.Value.Content);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.EventId);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.TargetId);
-                yield return entry.Value;
+                
+                if (entry.Value.EventId != nameof(SourceAddEvent) && entry.Value.EventId != nameof(SourceRemoveEvent))
+                    yield return entry.Value;
             }
         }
     }

--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -23,7 +23,7 @@ public static class NomadKuboEventStreamHandlerExtensions
     public static async Task<TResult> ResolveContentPointerAsync<TResult, TEventEntryContent>(this IReadOnlyNomadKuboEventStreamHandler<TEventEntryContent> handler, Cid cid, CancellationToken ctk)
     {
         var resolved = await handler.Client.ResolveDagCidAsync<TResult>(cid, nocache: !handler.KuboOptions.UseCache, ctk);
-        Guard.IsNotNull(resolved.Result);        
+        Guard.IsNotNull(resolved.Result);
         return resolved.Result;
     }
 
@@ -41,7 +41,7 @@ public static class NomadKuboEventStreamHandlerExtensions
 
         return roamingContent.Sources;
     }
-    
+
     /// <summary>
     /// Publishes the inner content to the roaming ipns key on <paramref name="eventStreamHandler"/>.
     /// </summary>
@@ -130,13 +130,13 @@ public static class NomadKuboEventStreamHandlerExtensions
     public static async IAsyncEnumerable<EventStreamEntry<Cid>> AdvanceSharedEventStreamAsync<TEventStreamEntryContent>(this IReadOnlyNomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Guard.IsNotNull(eventStreamHandler);
-        
+
         // Playback event stream
         // Order event entries by oldest first
         await foreach (var eventEntry in eventStreamHandler.ResolveEventStreamEntriesAsync(cancellationToken).OrderBy(x => x.TimestampUtc))
         {
             Guard.IsNotNull(eventEntry);
-            
+
             // Advance event stream for all listening objects
             await eventStreamHandler.ListeningEventStreamHandlers
                 .Where(x => x.Id == eventEntry.TargetId)
@@ -152,7 +152,7 @@ public static class NomadKuboEventStreamHandlerExtensions
     public static async IAsyncEnumerable<EventStreamEntry<Cid>> AdvanceEventStreamToAtLeastAsync<TEventStreamEntryContent>(this IReadOnlyNomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, DateTime maxDateTimeUtc, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Guard.IsNotNull(eventStreamHandler);
-        
+
         // Playback event stream
         // Order event entries by oldest first
         await foreach (var eventEntry in eventStreamHandler.ResolveEventStreamEntriesAsync(cancellationToken)
@@ -215,10 +215,10 @@ public static class NomadKuboEventStreamHandlerExtensions
                 var entry = await eventStreamHandler.ResolveContentPointerAsync<EventStreamEntry<Cid>, TEventStreamEntryContent>(entryCid, cancellationToken);
                 Guard.IsNotNull(entry);
                 entriesDict[entryCid] = entry;
-                
+
                 if (entry.Content is null)
                     throw new ArgumentNullException(nameof(entry.Content), $"{nameof(entry.Content)} was unexpectedly null on {entryCid}");
-                
+
                 Guard.IsNotNullOrWhiteSpace(entry.TargetId);
                 Guard.IsNotNullOrWhiteSpace(entry.EventId);
 
@@ -240,20 +240,25 @@ public static class NomadKuboEventStreamHandlerExtensions
                     if (eventStreamHandler.Sources.All(x => x != sourceAddEvent.AddedSourcePointer))
                     {
                         eventStreamHandler.Sources.Add(sourceAddEvent.AddedSourcePointer);
-                        Logger.LogInformation($"Added source {sourceAddEvent.AddedSourcePointer} to event stream handler {eventStreamHandler.Id}");   
+                        Logger.LogInformation($"Added source {sourceAddEvent.AddedSourcePointer} to event stream handler {eventStreamHandler.Id}");
                     }
 
                     // Add to queue
                     var newKvp = new KeyValuePair<Cid, Dictionary<Cid, EventStreamEntry<Cid>>>(sourceAddEvent.AddedSourcePointer, []);
-                    queue.Enqueue(newKvp);
-                    sourceEvents.Add(newKvp.Key, newKvp.Value);
+
+                    if (queue.All(x => x.Key != newKvp.Key))
+                        queue.Enqueue(newKvp);
+
+                    if (!sourceEvents.ContainsKey(newKvp.Key))
+                        sourceEvents.Add(newKvp.Key, newKvp.Value);
+
                     Logger.LogInformation($"Enqueued new source {newKvp.Key} for entry resolution");
 
                     // Unmark as removed if needed
                     if (removedSources.Any(x => x == sourceAddEvent.AddedSourcePointer))
                     {
                         removedSources.Remove(sourceAddEvent.AddedSourcePointer);
-                        Logger.LogInformation($"Unmarked source {sourceAddEvent.AddedSourcePointer} as removed {eventStreamHandler.Id}");   
+                        Logger.LogInformation($"Unmarked source {sourceAddEvent.AddedSourcePointer} as removed {eventStreamHandler.Id}");
                     }
                 }
                 // Removed source
@@ -266,7 +271,7 @@ public static class NomadKuboEventStreamHandlerExtensions
 
                     if (eventStreamHandler.Sources.Contains(sourceRemoveEvent.RemovedSourcePointer))
                     {
-                        Logger.LogInformation($"Removed source {sourceRemoveEvent.RemovedSourcePointer} from event stream handler {eventStreamHandler.Id}");   
+                        Logger.LogInformation($"Removed source {sourceRemoveEvent.RemovedSourcePointer} from event stream handler {eventStreamHandler.Id}");
                         eventStreamHandler.Sources.Remove(sourceRemoveEvent.RemovedSourcePointer);
                     }
 
@@ -274,7 +279,7 @@ public static class NomadKuboEventStreamHandlerExtensions
                     // Rather than removing the event stream source and entries,
                     // mark as 'removed' and don't yield.
                     removedSources.Add(sourceRemoveEvent.RemovedSourcePointer);
-                    Logger.LogInformation($"Marked source {sourceRemoveEvent.RemovedSourcePointer} as removed {eventStreamHandler.Id}");   
+                    Logger.LogInformation($"Marked source {sourceRemoveEvent.RemovedSourcePointer} as removed {eventStreamHandler.Id}");
                 }
             }
         }
@@ -299,7 +304,7 @@ public static class NomadKuboEventStreamHandlerExtensions
                 Guard.IsNotNullOrWhiteSpace(entry.Value.Content);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.EventId);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.TargetId);
-                
+
                 if (entry.Value.EventId != nameof(SourceAddEvent) && entry.Value.EventId != nameof(SourceRemoveEvent))
                     yield return entry.Value;
             }

--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -189,7 +189,6 @@ public static class NomadKuboEventStreamHandlerExtensions
         {
             // Resolve event stream for each source
             var sourceCid = sourceKvp.Key;
-            Logger.LogInformation($"Processing event stream {sourceCid}");
             Guard.IsNotNullOrWhiteSpace(sourceCid);
 
             var eventStream = await eventStreamHandler.ResolveContentPointerAsync<EventStream<Cid>, TEventStreamEntryContent>(sourceCid, cancellationToken);
@@ -212,7 +211,6 @@ public static class NomadKuboEventStreamHandlerExtensions
             var entriesDict = sourceKvp.Value;
             foreach (var entryCid in eventStream.Entries)
             {
-                Logger.LogInformation($"Processing event stream entry {sourceCid}");
                 Guard.IsNotNullOrWhiteSpace(entryCid);
                 var entry = await eventStreamHandler.ResolveContentPointerAsync<EventStreamEntry<Cid>, TEventStreamEntryContent>(entryCid, cancellationToken);
                 Guard.IsNotNull(entry);

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -15,13 +15,22 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.2.0</Version>
+		<Version>0.2.1</Version>
 		<Product>OwlCore</Product>
 		<Description>Shared tooling for building Nomad-enabled applications on ipfs</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.2.1 ---
+[Improvements]
+Add guards and checks around resolving event entries.
+Avoid yielding SourceAddEvent and SourceRemoveEvent to consuming application.
+Add logging, fix potential SourceAddEvent and SourceRemoveEvent issues.
+
+[Fixes]
+Fixed double queuing for discovered SourceAddEvents.
+
 --- 0.2.0 ---
 [Breaking]
 Migrated to OwlCore.Nomad 0.5.0, inherited breaking changes.

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -91,8 +91,8 @@ Initial release of OwlCore.Nomad.Kubo.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="OwlCore.Kubo" Version="0.16.4" />
-    <PackageReference Include="OwlCore.Nomad" Version="0.5.0" />
+		<PackageReference Include="OwlCore.Kubo" Version="0.17.0" />
+    	<PackageReference Include="OwlCore.Nomad" Version="0.5.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- **Add guards, cleanup**
- **Add guards and checks around resolving event entries**
- **Avoid yielding SourceAddEvent and SourceRemoveEvent to consuming application**
- **Add logging, fix potential SourceAddEvent and SourceRemoveEvent issues**
- **Cleanup extraneous logging**
- **Fixed double queuing for discovered SourceAddEvents**
