### PR TITLE
Release 0.15.0

### DIFF
--- a/src/Events/EventEntryContent.cs
+++ b/src/Events/EventEntryContent.cs
@@ -1,8 +1,0 @@
-﻿namespace OwlCore.Nomad.Kubo.Events;
-
-/// <summary>
-/// A base class for content stored in the event stream.
-/// </summary>
-/// <param name="TargetId">A unique identifier for the target object which this event is applied to.</param>
-/// <param name="EventId">A unique identifier of the event. Used for further deserialization.</param>
-public abstract record EventEntryContent(string TargetId, string EventId);

--- a/src/Events/SourceAddEvent.cs
+++ b/src/Events/SourceAddEvent.cs
@@ -1,8 +1,0 @@
-﻿namespace OwlCore.Nomad.Kubo.Events;
-
-/// <summary>
-/// Content for an event entry that signifies a source being added to the event stream.
-/// </summary>
-/// <param name="TargetId">A unique identifier for the runtime object this event was applied to.</param>
-/// <param name="AddedSourcePointer">A pointer to the source that was added.</param>
-public record SourceAddEvent(string TargetId, string AddedSourcePointer) : EventEntryContent(TargetId, nameof(SourceAddEvent));

--- a/src/Events/SourceRemoveEvent.cs
+++ b/src/Events/SourceRemoveEvent.cs
@@ -1,8 +1,0 @@
-﻿namespace OwlCore.Nomad.Kubo.Events;
-
-/// <summary>
-/// Content for an event entry that signifies a source being removed from the event stream.
-/// </summary>
-/// <param name="TargetId">A unique identifier for the runtime object this event was applied to.</param>
-/// <param name="RemovedSourcePointer">A pointer to the source that was removed.</param>
-public record SourceRemoveEvent(string TargetId, string RemovedSourcePointer) : EventEntryContent(TargetId, nameof(SourceRemoveEvent));

--- a/src/Events/ValueUpdateEvent.cs
+++ b/src/Events/ValueUpdateEvent.cs
@@ -1,0 +1,79 @@
+﻿using Ipfs;
+
+namespace OwlCore.Nomad.Kubo.Events;
+
+/// <summary>
+/// Used to set property values, set an item in a bag or collection, or set the value for a key. 
+/// </summary>
+/// <remarks>
+/// This one event should cover everything we need: properties, bags, lists, hashsets, dictionaries, sorted or unsorted, and so on. We took the individual common traits between them all and put them into a "trait space" where we could do a per-hyperedge complete bipartite component analysis with the other traits in the space. 
+/// <para/>
+/// It started out like this:
+/// <para/>
+/// ```
+/// <para/>
+/// - Ordered vs Unordered
+/// <para/>
+/// - Positional vs Non-positional
+/// <para/>
+/// - Unique/Distinguishable vs Non-Unique/Indistinguishable
+/// <para/>
+/// - Keyed vs Non-Keyed
+/// <para/>
+/// - Capacity-limit vs No capacity limit
+/// <para/>
+/// - Mutable vs Immutable
+/// <para/>
+/// - In/Add vs Out/Remove
+/// <para/>
+/// ```
+/// <para/>
+/// Then, picking one hyperedge (here, it's position) and doing the comparison, we get a DAG with one way to stack the types:
+/// <para/>
+/// ```
+/// <para/>
+/// - Ordered vs Unordered
+/// <para/>
+/// - Positional vs Non-positional:
+/// <para/>
+/// --- Positional indexing
+/// <para/>
+/// -----Integer indexing (ordered, non-unique)
+/// <para/>
+/// ------ Unrestricted access (list)
+/// <para/>
+/// ------ End-based access (queue, stack, deque)
+/// <para/>
+/// -------- First (in/out) (temporal/positional)
+/// <para/>
+/// -------- Last (in/out) (temporal/positional)
+/// <para/>
+/// ---- Key indexing (unique)
+/// <para/>
+/// ------ Ordered (SortedDictionary)
+/// <para/>
+/// ------ Unordered (Dictionary)
+/// <para/>
+/// --- Single position (properties)
+/// <para/>
+/// --- No positional indexing (unordered list, bag)
+/// <para/>
+/// - Unique/Distinguishable vs Non-Unique/Indistinguishable
+/// <para/>
+/// - Keyed vs Non-Keyed
+/// <para/>
+/// - Capacity-limit vs No capacity limit
+/// <para/>
+/// - Mutable vs Immutable
+/// <para/>
+/// - In/Add vs Out/Remove
+/// <para/>
+/// ```
+/// <para/>
+/// Notice how 'ordering' neatly disappears and 'uniqueness' neatly appears as you go from "Fully positional" to "No position of any kind".
+/// <para/>
+/// We're able to expand any of these top-level axes and explore the boundary to determine existing known configurations from other axes. For example, we expanded along "positional vs non-positional" here, but we could have also expanded along "Ordered vs Unordered" into the other axes to check for consistency. 
+/// <para/>
+/// In the scenario set up here, the hyperedge picked (positional --- non-positional) was enough information to understand how to flatten it down to a single record type that other types build on top on without changing, while being stored in a time-ordered event stream.
+/// </remarks>
+public record ValueUpdateEvent(DagCid? Key, DagCid? Value, bool Unset);

--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -193,7 +193,7 @@ public static class NomadKuboEventStreamHandlerExtensions
             foreach (var entryCid in eventStream.Entries)
             {
                 Guard.IsNotNullOrWhiteSpace(entryCid?.ToString());
-                var entry = await eventStreamHandler.ResolveContentPointerAsync<EventStreamEntry<DagCid>, TEventStreamEntryContent>(entryCid, cancellationToken);
+                var entry = await eventStreamHandler.Client.Dag.GetAsync<EventStreamEntry<DagCid>>(entryCid, cancel: cancellationToken);
                 Guard.IsNotNull(entry);
                 entriesDict[entryCid] = entry;
 

--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -204,7 +204,7 @@ public static class NomadKuboEventStreamHandlerExtensions
                 Guard.IsNotNullOrWhiteSpace(entry.EventId);
 
                 // Added source
-                if (entry.EventId == "SourceAddEvent")
+                if (entry.EventId == ReservedEventIds.NomadEventStreamSourceAddEvent)
                 {
                     var entryContent = await eventStreamHandler.Client.Dag.GetAsync<Cid>(entry.Content, cancel: cancellationToken);
 
@@ -234,7 +234,7 @@ public static class NomadKuboEventStreamHandlerExtensions
                     }
                 }
                 // Removed source
-                else if (entry.EventId == "SourceRemoveEvent")
+                else if (entry.EventId == ReservedEventIds.NomadEventStreamSourceRemoveEvent)
                 {
                     var entryContent = await eventStreamHandler.Client.Dag.GetAsync<Cid>(entry.Content, cancel: cancellationToken);
 
@@ -274,7 +274,7 @@ public static class NomadKuboEventStreamHandlerExtensions
                 Guard.IsNotNullOrWhiteSpace(entry.Value.EventId);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.TargetId);
 
-                if (entry.Value.EventId != "SourceAddEvent" && entry.Value.EventId != "SourceRemoveEvent")
+                if (entry.Value.EventId != ReservedEventIds.NomadEventStreamSourceAddEvent && entry.Value.EventId != ReservedEventIds.NomadEventStreamSourceRemoveEvent)
                     yield return entry.Value;
             }
         }

--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -5,7 +5,6 @@ using OwlCore.Kubo;
 using OwlCore.ComponentModel;
 using OwlCore.Diagnostics;
 using OwlCore.Extensions;
-using OwlCore.Nomad.Kubo.Events;
 using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
@@ -88,7 +87,7 @@ public static class NomadKuboEventStreamHandlerExtensions
     /// <param name="targetId">A unique identifier for the provided <paramref name="handler"/> that can be used to reapply the event later.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A task containing the new event stream entry.</returns>
-    public static async Task<EventStreamEntry<Cid>> AppendEventStreamEntryAsync<T>(this INomadKuboEventStreamHandler<T> handler, Cid updateEventContentCid, string eventId, string targetId, CancellationToken cancellationToken)
+    public static async Task<EventStreamEntry<DagCid>> AppendEventStreamEntryAsync<T>(this INomadKuboEventStreamHandler<T> handler, DagCid updateEventContentCid, string eventId, string targetId, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var client = handler.Client;
@@ -99,7 +98,7 @@ public static class NomadKuboEventStreamHandlerExtensions
             cancellationToken.ThrowIfCancellationRequested();
 
             // Append the event to the local event stream.
-            var newEventStreamEntry = new EventStreamEntry<Cid>
+            var newEventStreamEntry = new EventStreamEntry<DagCid>
             {
                 TargetId = targetId,
                 EventId = eventId,
@@ -111,7 +110,7 @@ public static class NomadKuboEventStreamHandlerExtensions
             var newEventStreamEntryCid = await client.Dag.PutAsync(newEventStreamEntry, pin: handler.KuboOptions.ShouldPin, cancel: cancellationToken);
 
             // Add new entry cid to event stream content.
-            handler.LocalEventStream.Entries.Add(newEventStreamEntryCid);
+            handler.LocalEventStream.Entries.Add((DagCid)newEventStreamEntryCid);
 
             return newEventStreamEntry;
         }
@@ -124,10 +123,10 @@ public static class NomadKuboEventStreamHandlerExtensions
     /// <param name="client">The client to use to resolve the pointer.</param>
     /// <param name="useCache">Whether to use cache or not.</param>
     /// <param name="token">A token that can be used to cancel the ongoing operation.</param>
-    public static async Task<EventStreamEntry<Cid>> ContentPointerToStreamEntryAsync(Cid cid, ICoreApi client,
+    public static async Task<EventStreamEntry<DagCid>> ContentPointerToStreamEntryAsync(Cid cid, ICoreApi client,
         bool useCache, CancellationToken token)
     {
-        var (streamEntry, _) = await client.ResolveDagCidAsync<EventStreamEntry<Cid>>(cid, nocache: !useCache, token);
+        var (streamEntry, _) = await client.ResolveDagCidAsync<EventStreamEntry<DagCid>>(cid, nocache: !useCache, token);
         Guard.IsNotNull(streamEntry);
         return streamEntry;
     }
@@ -138,7 +137,7 @@ public static class NomadKuboEventStreamHandlerExtensions
     /// <param name="eventStreamHandler">The event stream handler whose sources are resolved to crawl for event stream entries.</param>
     /// <param name="maxDateTimeUtc">The max datetime to advance the stream to.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public static async IAsyncEnumerable<EventStreamEntry<Cid>> AdvanceEventStreamToAtLeastAsync<TEventStreamEntryContent>(this INomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, DateTime maxDateTimeUtc, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public static async IAsyncEnumerable<EventStreamEntry<DagCid>> AdvanceEventStreamToAtLeastAsync<TEventStreamEntryContent>(this INomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, DateTime maxDateTimeUtc, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(eventStreamHandler);
 
@@ -161,10 +160,10 @@ public static class NomadKuboEventStreamHandlerExtensions
     /// </summary>
     /// <param name="eventStreamHandler">The event stream handler whose sources are resolved to crawl for event stream entries.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public static async IAsyncEnumerable<EventStreamEntry<Cid>> ResolveEventStreamEntriesAsync<TEventStreamEntryContent>(this INomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public static async IAsyncEnumerable<EventStreamEntry<DagCid>> ResolveEventStreamEntriesAsync<TEventStreamEntryContent>(this INomadKuboEventStreamHandler<TEventStreamEntryContent> eventStreamHandler, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         // Resolve initial sources
-        var sourceEvents = new Dictionary<Cid, Dictionary<Cid, EventStreamEntry<Cid>>>();
+        var sourceEvents = new Dictionary<Cid, Dictionary<DagCid, EventStreamEntry<DagCid>>>();
 
         foreach (var source in eventStreamHandler.Sources)
             sourceEvents.Add(source, []);
@@ -173,14 +172,14 @@ public static class NomadKuboEventStreamHandlerExtensions
         // Remove from this if source is re-added
         var removedSources = new HashSet<Cid>();
 
-        var queue = new Queue<KeyValuePair<Cid, Dictionary<Cid, EventStreamEntry<Cid>>>>(sourceEvents);
+        var queue = new Queue<KeyValuePair<Cid, Dictionary<DagCid, EventStreamEntry<DagCid>>>>(sourceEvents);
         while (queue.Count > 0 && queue.Dequeue() is var sourceKvp)
         {
             // Resolve event stream for each source
             var sourceCid = sourceKvp.Key;
             Guard.IsNotNullOrWhiteSpace(sourceCid);
 
-            var eventStream = await eventStreamHandler.ResolveContentPointerAsync<EventStream<Cid>, TEventStreamEntryContent>(sourceCid, cancellationToken);
+            var eventStream = await eventStreamHandler.ResolveContentPointerAsync<EventStream<DagCid>, TEventStreamEntryContent>(sourceCid, cancellationToken);
             Guard.IsNotNullOrWhiteSpace(eventStreamHandler.EventStreamHandlerId);
 
             if (removedSources.Contains(sourceCid))
@@ -193,8 +192,8 @@ public static class NomadKuboEventStreamHandlerExtensions
             var entriesDict = sourceKvp.Value;
             foreach (var entryCid in eventStream.Entries)
             {
-                Guard.IsNotNullOrWhiteSpace(entryCid);
-                var entry = await eventStreamHandler.ResolveContentPointerAsync<EventStreamEntry<Cid>, TEventStreamEntryContent>(entryCid, cancellationToken);
+                Guard.IsNotNullOrWhiteSpace(entryCid?.ToString());
+                var entry = await eventStreamHandler.ResolveContentPointerAsync<EventStreamEntry<DagCid>, TEventStreamEntryContent>(entryCid, cancellationToken);
                 Guard.IsNotNull(entry);
                 entriesDict[entryCid] = entry;
 
@@ -207,15 +206,17 @@ public static class NomadKuboEventStreamHandlerExtensions
                 // Added source
                 if (entry.EventId == "SourceAddEvent")
                 {
+                    var entryContent = await eventStreamHandler.Client.Dag.GetAsync<Cid>(entry.Content, cancel: cancellationToken);
+
                     // Add to handler
-                    if (eventStreamHandler.Sources.All(x => x != entry.Content))
+                    if (eventStreamHandler.Sources.All(x => x != entryContent))
                     {
-                        eventStreamHandler.Sources.Add(entry.Content);
-                        Logger.LogInformation($"Added source {entry.Content} to event stream handler {eventStreamHandler.EventStreamHandlerId}");
+                        eventStreamHandler.Sources.Add(entryContent);
+                        Logger.LogInformation($"Added source {entryContent} to event stream handler {eventStreamHandler.EventStreamHandlerId}");
                     }
 
                     // Add to queue
-                    var newKvp = new KeyValuePair<Cid, Dictionary<Cid, EventStreamEntry<Cid>>>(entry.Content, []);
+                    var newKvp = new KeyValuePair<Cid, Dictionary<DagCid, EventStreamEntry<DagCid>>>(entryContent, []);
 
                     if (queue.All(x => x.Key != newKvp.Key))
                         queue.Enqueue(newKvp);
@@ -226,19 +227,21 @@ public static class NomadKuboEventStreamHandlerExtensions
                     Logger.LogInformation($"Enqueued new source {newKvp.Key} for entry resolution");
 
                     // Unmark as removed if needed
-                    if (removedSources.Any(x => x == entry.Content))
+                    if (removedSources.Any(x => x == entryContent))
                     {
-                        removedSources.Remove(entry.Content);
-                        Logger.LogInformation($"Unmarked source {entry.Content} as removed {eventStreamHandler.EventStreamHandlerId}");
+                        removedSources.Remove(entryContent);
+                        Logger.LogInformation($"Unmarked source {entryContent} as removed {eventStreamHandler.EventStreamHandlerId}");
                     }
                 }
                 // Removed source
                 else if (entry.EventId == "SourceRemoveEvent")
                 {
-                    if (eventStreamHandler.Sources.Contains(entry.Content))
+                    var entryContent = await eventStreamHandler.Client.Dag.GetAsync<Cid>(entry.Content, cancel: cancellationToken);
+
+                    if (eventStreamHandler.Sources.Contains(entryContent))
                     {
-                        Logger.LogInformation($"Removed source {entry.Content} from event stream handler {eventStreamHandler.EventStreamHandlerId}");
-                        eventStreamHandler.Sources.Remove(entry.Content);
+                        Logger.LogInformation($"Removed source {entryContent} from event stream handler {eventStreamHandler.EventStreamHandlerId}");
+                        eventStreamHandler.Sources.Remove(entryContent);
                     }
 
                     // Don't want to re-resolve if source is re-added
@@ -267,7 +270,7 @@ public static class NomadKuboEventStreamHandlerExtensions
             foreach (var entry in eventStreamEntries)
             {
                 Guard.IsNotNull(entry.Value);
-                Guard.IsNotNullOrWhiteSpace(entry.Value.Content);
+                Guard.IsNotNullOrWhiteSpace(entry.Value.Content?.ToString());
                 Guard.IsNotNullOrWhiteSpace(entry.Value.EventId);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.TargetId);
 

--- a/src/INomadKuboEventStreamHandler.cs
+++ b/src/INomadKuboEventStreamHandler.cs
@@ -9,7 +9,7 @@ namespace OwlCore.Nomad.Kubo;
 /// <remarks>
 /// If you're reading roaming data that you aren't publishing to, you don't need to resolve and replay the event stream.
 /// </remarks>
-public interface INomadKuboEventStreamHandler<in TEventEntryContent> : IEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>
+public interface INomadKuboEventStreamHandler<in TEventEntryContent> : IEventStreamHandler<DagCid, Cid, EventStream<DagCid>, EventStreamEntry<DagCid>>
 {
     /// <summary>
     /// The name of an Ipns key containing a Nomad event stream that can be appended and republished to modify the current folder.
@@ -40,7 +40,7 @@ public interface INomadKuboEventStreamHandler<in TEventEntryContent> : IEventStr
     /// <param name="eventStreamEntry">The event stream entry</param>
     /// <param name="eventEntryContent">The update to apply without side effects.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public Task ApplyEntryUpdateAsync(EventStreamEntry<Cid> eventStreamEntry, TEventEntryContent eventEntryContent, CancellationToken cancellationToken = default);
+    public Task ApplyEntryUpdateAsync(EventStreamEntry<DagCid> eventStreamEntry, TEventEntryContent eventEntryContent, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Appends the provided event entry of type <typeparamref name="TEventEntryContent"/> to the underlying event stream.
@@ -51,5 +51,5 @@ public interface INomadKuboEventStreamHandler<in TEventEntryContent> : IEventStr
     /// <param name="timestampUtc">The recorded UTC timestamp when this event entry was applied.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A task containing the event stream entry that was applied from the update.</returns>
-    public Task<EventStreamEntry<Cid>> AppendNewEntryAsync(string targetId, string eventId, TEventEntryContent eventEntryContent, DateTime? timestampUtc = null, CancellationToken cancellationToken = default);
+    public Task<EventStreamEntry<DagCid>> AppendNewEntryAsync(string targetId, string eventId, TEventEntryContent eventEntryContent, DateTime? timestampUtc = null, CancellationToken cancellationToken = default);
 }

--- a/src/INomadKuboEventStreamHandler.cs
+++ b/src/INomadKuboEventStreamHandler.cs
@@ -37,15 +37,19 @@ public interface INomadKuboEventStreamHandler<in TEventEntryContent> : IEventStr
     /// <summary>
     /// Applies an event stream update to this object without side effects.
     /// </summary>
-    /// <param name="updateEvent">The update to apply without side effects.</param>
+    /// <param name="eventStreamEntry">The event stream entry</param>
+    /// <param name="eventEntryContent">The update to apply without side effects.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public Task ApplyEntryUpdateAsync(TEventEntryContent updateEvent, CancellationToken cancellationToken);
-    
+    public Task ApplyEntryUpdateAsync(EventStreamEntry<Cid> eventStreamEntry, TEventEntryContent eventEntryContent, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Appends the provided event entry of type <typeparamref name="TEventEntryContent"/> to the underlying event stream.
     /// </summary>
-    /// <param name="updateEvent">The update event data to apply and persist.</param>
+    /// <param name="targetId">A unique identifier that represents the scope the applied event occurred within.</param>
+    /// <param name="eventId">A unique identifier for the event that occured within this <paramref name="targetId"/>.</param>
+    /// <param name="eventEntryContent">The update event data to apply and persist.</param>
+    /// <param name="timestampUtc">The recorded UTC timestamp when this event entry was applied.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A task containing the event stream entry that was applied from the update.</returns>
-    public Task<EventStreamEntry<Cid>> AppendNewEntryAsync(TEventEntryContent updateEvent, CancellationToken cancellationToken = default);
+    public Task<EventStreamEntry<Cid>> AppendNewEntryAsync(string targetId, string eventId, TEventEntryContent eventEntryContent, DateTime? timestampUtc = null, CancellationToken cancellationToken = default);
 }

--- a/src/KeyExchange.cs
+++ b/src/KeyExchange.cs
@@ -116,7 +116,7 @@ public static class KeyExchange
     /// It's HIGHLY recommended to use an encryption pubsub layer for your peer room. 
     /// </remarks>
     /// <param name="peerRoom">The room to perform the exchange in.</param>
-    /// <param name="localKey">The local key for this node. If <paramref name="isReceiver"/> is false, this key will be sent, otherwise the received key will be added in a new <see cref="SourceAddEvent"/> to the event stream at this key.</param>
+    /// <param name="localKey">The local key for this node. If <paramref name="isReceiver"/> is false, this key will be sent, otherwise the received key will be added in a new <see cref="ReservedEventIds.NomadEventStreamSourceAddEvent"/> to the event stream at this key.</param>
     /// <param name="roamingKeyName">The name to use for the imported roaming key.</param>
     /// <param name="isReceiver">When true, this method will act as the receiver. When false, this method will act as the sender.</param>
     /// <param name="kuboOptions">Options for data published to ipfs.</param>
@@ -211,7 +211,7 @@ public static class KeyExchange
             var eventEntry = new EventStreamEntry<DagCid>
             {
                 TargetId = roamingKeyId,
-                EventId = "SourceAddEvent",
+                EventId = ReservedEventIds.NomadEventStreamSourceAddEvent,
                 Content = (DagCid)newSourceDagCid,
                 TimestampUtc = DateTime.UtcNow,
             };

--- a/src/NomadKeyGen.cs
+++ b/src/NomadKeyGen.cs
@@ -19,7 +19,7 @@ public static class NomadKeyGen
     /// <param name="eventStreamLabel">The label to use for the created local event stream.</param>
     /// <param name="client">A client to use for communicating with ipfs.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public static async Task<((IKey Key, EventStream<Cid> Value) Local, (IKey Key, TRoaming Value) Roaming)> CreateAsync<TRoaming>(string localKeyName, string roamingKeyName, string eventStreamLabel, Func<IKey, IKey, TRoaming> getDefaultRoamingValue, ICoreApi client, CancellationToken cancellationToken)
+    public static async Task<((IKey Key, EventStream<DagCid> Value) Local, (IKey Key, TRoaming Value) Roaming)> CreateAsync<TRoaming>(string localKeyName, string roamingKeyName, string eventStreamLabel, Func<IKey, IKey, TRoaming> getDefaultRoamingValue, ICoreApi client, CancellationToken cancellationToken)
     {
         // Get or create ipns key
         var enumerableKeys = await client.Key.ListAsync(cancellationToken);
@@ -41,7 +41,7 @@ public static class NomadKeyGen
         // otherwise we'd have an extra step during pairing, exporting local separately from roaming from A to B.
         // ---
         // This is can be retroactively handled when publishing an event stream to roaming, but it's best if done in the seed values.
-        var defaultLocalValue = new EventStream<Cid>
+        var defaultLocalValue = new EventStream<DagCid>
         {
             Label = eventStreamLabel,
             Entries = [],
@@ -61,9 +61,9 @@ public static class NomadKeyGen
     /// <param name="eventStreamLabel">The label to use for the created local event stream.</param>
     /// <param name="client">A client to use for communicating with ipfs.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public static Task<(IKey Key, EventStream<Cid> Value)> GetOrCreateLocalAsync(string localKeyName, string eventStreamLabel, IKuboOptions kuboOptions, ICoreApi client, CancellationToken cancellationToken)
+    public static Task<(IKey Key, EventStream<DagCid> Value)> GetOrCreateLocalAsync(string localKeyName, string eventStreamLabel, IKuboOptions kuboOptions, ICoreApi client, CancellationToken cancellationToken)
     {
-        return client.GetOrCreateKeyAsync(localKeyName, _ => new EventStream<Cid>
+        return client.GetOrCreateKeyAsync(localKeyName, _ => new EventStream<DagCid>
         {
             Label = eventStreamLabel,
             Entries = [],

--- a/src/NomadKuboEventStreamHandler.cs
+++ b/src/NomadKuboEventStreamHandler.cs
@@ -14,10 +14,10 @@ public abstract class NomadKuboEventStreamHandler<TEventEntryContent> : INomadKu
     public required string EventStreamHandlerId { get; init; }
 
     /// <inheritdoc />
-    public EventStreamEntry<Cid>? EventStreamPosition { get; set; }
+    public EventStreamEntry<DagCid>? EventStreamPosition { get; set; }
 
     /// <inheritdoc />
-    public required EventStream<Cid> LocalEventStream { get; set; }
+    public required EventStream<DagCid> LocalEventStream { get; set; }
 
     /// <inheritdoc />
     public virtual required ICollection<Cid> Sources { get; init; }
@@ -35,7 +35,7 @@ public abstract class NomadKuboEventStreamHandler<TEventEntryContent> : INomadKu
     public required IKuboOptions KuboOptions { get; set; }
 
     /// <inheritdoc />
-    public virtual async Task AdvanceEventStreamAsync(EventStreamEntry<Cid> streamEntry, CancellationToken cancellationToken)
+    public virtual async Task AdvanceEventStreamAsync(EventStreamEntry<DagCid> streamEntry, CancellationToken cancellationToken)
     {
         var (result, _) = await Client.ResolveDagCidAsync<TEventEntryContent>(streamEntry.Content, nocache: false, cancellationToken);
         if (result is not null)
@@ -45,11 +45,11 @@ public abstract class NomadKuboEventStreamHandler<TEventEntryContent> : INomadKu
     }
 
     /// <inheritdoc />
-    public virtual async Task<EventStreamEntry<Cid>> AppendNewEntryAsync(string targetId, string eventId, TEventEntryContent eventEntryContent, DateTime? timestampUtc = null, CancellationToken cancellationToken = default)
+    public virtual async Task<EventStreamEntry<DagCid>> AppendNewEntryAsync(string targetId, string eventId, TEventEntryContent eventEntryContent, DateTime? timestampUtc = null, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(eventEntryContent);
         var localUpdateEventCid = await Client.Dag.PutAsync(eventEntryContent, pin: KuboOptions.ShouldPin, cancel: cancellationToken);
-        var newEntry = await this.AppendEventStreamEntryAsync(localUpdateEventCid, eventId, targetId, cancellationToken);
+        var newEntry = await this.AppendEventStreamEntryAsync((DagCid)localUpdateEventCid, eventId, targetId, cancellationToken);
         return newEntry;
     }
 
@@ -57,5 +57,5 @@ public abstract class NomadKuboEventStreamHandler<TEventEntryContent> : INomadKu
     public abstract Task ResetEventStreamPositionAsync(CancellationToken cancellationToken);
 
     /// <inheritdoc />
-    public abstract Task ApplyEntryUpdateAsync(EventStreamEntry<Cid> streamEntry, TEventEntryContent updateEvent, CancellationToken cancellationToken);
+    public abstract Task ApplyEntryUpdateAsync(EventStreamEntry<DagCid> streamEntry, TEventEntryContent updateEvent, CancellationToken cancellationToken);
 }

--- a/src/NomadKuboEventStreamHandlerConfig.cs
+++ b/src/NomadKuboEventStreamHandlerConfig.cs
@@ -21,7 +21,7 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     /// <summary>
     /// The value of the local event stream.
     /// </summary>
-    public EventStream<Cid>? LocalValue { get; set; }
+    public EventStream<DagCid>? LocalValue { get; set; }
 
     /// <summary>
     /// The key used to publish the roaming data.
@@ -49,5 +49,5 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     /// <remarks>
     /// A null value indicates the event stream entries have not been resolved.
     /// </remarks>
-    public ICollection<EventStreamEntry<Cid>>? ResolvedEventStreamEntries { get; set; }
+    public ICollection<EventStreamEntry<DagCid>>? ResolvedEventStreamEntries { get; set; }
 }

--- a/src/NomadKuboRepositoryBase.cs
+++ b/src/NomadKuboRepositoryBase.cs
@@ -82,7 +82,7 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
             // Resolve local value if needed.
             if (config.LocalValue is null && config.LocalKey is not null)
             {
-                var (resolvedLocal, _) = await Client.ResolveDagCidAsync<EventStream<Cid>>(config.LocalKey.Id, nocache: !KuboOptions.UseCache, cancellationToken);
+                var (resolvedLocal, _) = await Client.ResolveDagCidAsync<EventStream<DagCid>>(config.LocalKey.Id, nocache: !KuboOptions.UseCache, cancellationToken);
                 config.LocalValue = resolvedLocal;
             }
         }
@@ -196,4 +196,4 @@ public delegate TReadOnly ReadOnlyFromHandlerConfigDelegate<out TReadOnly, TRoam
 /// <param name="handlerConfig">The handler configuration to use.</param>
 /// <returns>A new instance of the modifiable type.</returns>
 public delegate TModifiable ModifiableFromHandlerConfigDelegate<out TModifiable, TRoaming>(NomadKuboEventStreamHandlerConfig<TRoaming> handlerConfig)
-    where TModifiable : IEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>;
+    where TModifiable : IEventStreamHandler<DagCid, Cid, EventStream<DagCid>, EventStreamEntry<DagCid>>;

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -17,7 +17,7 @@
 		<Author>Arlo Godfrey</Author>
 		<Version>0.15.0</Version>
 		<Product>OwlCore</Product>
-		<Description>Build a modifiable application domain across Kubo peers with eventual consistency. Easily cover the gap between "User device" and "User".</Description>
+		<Description>Build a modifiable application domain across Kubo peers with eventual consistency. Cover the gap between "User device" and "User".</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -15,13 +15,21 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.14.1</Version>
+		<Version>0.15.0</Version>
 		<Product>OwlCore</Product>
 		<Description>Shared tooling for building Nomad-enabled applications on ipfs</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.15.0 ---
+[Breaking]
+Removed SourceAddEvent and SourceRemoveEvent. The EventId for these are now hardcoded.
+The logic for NomadKuboEventStreamHandlerExtensions.ResolveEventStreamEntriesAsync has been updated. 
+Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore.Nomad.Storage 0.10.0.
+All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.
+Existing event streams will need to be recreated or migrated to the new format. 
+
 --- 0.14.1 ---
 [Fixes]
 KeyExchange.ReceiveRoamingKeyAsync now throws when stderr is received, instead of discarding the error.
@@ -197,12 +205,15 @@ Initial release of OwlCore.Nomad.Kubo.
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
 		<PackageReference Include="OwlCore.Kubo" Version="0.20.0" />
-    	<PackageReference Include="OwlCore.Nomad" Version="0.9.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\ocnomad\src\OwlCore.Nomad.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -204,7 +204,7 @@ Initial release of OwlCore.Nomad.Kubo.
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
 		<PackageReference Include="OwlCore.Kubo" Version="0.20.1" />
-    	<PackageReference Include="OwlCore.Nomad" Version="0.10.0" />
+    	<PackageReference Include="OwlCore.Nomad" Version="0.10.1" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -29,6 +29,9 @@ Existing event streams will need to be recreated or migrated to the new model ch
 Removed SourceAddEvent and SourceRemoveEvent. The EventId for these have changed and have been moved to a static ReservedEventIds class.
 All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.
 
+[Improvement]
+The method NomadKuboEventStreamHandlerBase.AppendNewEntryAsync now has a default body as has been marked virtual. It no longer needs to be overriden in a derived class if the default behavior is desired.
+
 --- 0.14.1 ---
 [Fixes]
 KeyExchange.ReceiveRoamingKeyAsync now throws when stderr is received, instead of discarding the error.

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -17,7 +17,7 @@
 		<Author>Arlo Godfrey</Author>
 		<Version>0.15.0</Version>
 		<Product>OwlCore</Product>
-		<Description>Shared tooling for building Nomad-enabled applications on ipfs</Description>
+		<Description>Build a modifiable application domain across Kubo peers with eventual consistency. Easily cover the gap between "User device" and "User".</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -28,6 +28,8 @@ Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore
 Existing event streams will need to be recreated or migrated to the new model changes. 
 Removed SourceAddEvent and SourceRemoveEvent. The EventId for these have changed and have been moved to a static ReservedEventIds class.
 All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.
+The interface method INomadKuboEventStreamHandler.AppendNewEntryAsync has an update signature. The parameters were previously only TEventEntryContent and a CancellationToken, but are now a targetId, an eventId, TEventEntryContent, a timestampUtc and a cancellationToken in that order.
+The interface method INomadKuboEventStreamHandler.ApplyEntryUpdateAsync has an updated signature. The parameters were previously only TEventEntryContent and a CancellationToken, but are now an event stream entry, TEventEntryContent and a cancellationToken in that order.
 
 [Improvement]
 The method NomadKuboEventStreamHandlerBase.AppendNewEntryAsync now has a default body as has been marked virtual. It no longer needs to be overriden in a derived class if the default behavior is desired.

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -24,7 +24,7 @@
 		<PackageReleaseNotes>
 --- 0.15.0 ---
 [Breaking]
-Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore.Nomad.Storage 0.10.0.
+Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0.
 Existing event streams will need to be recreated or migrated to the new model changes. 
 Removed SourceAddEvent and SourceRemoveEvent. The EventId for these have changed and have been moved to a static ReservedEventIds class.
 All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -201,19 +201,16 @@ Initial release of OwlCore.Nomad.Kubo.
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
-		<PackageReference Include="OwlCore.Kubo" Version="0.20.0" />
-		<PackageReference Include="PolySharp" Version="1.14.1">
+		<PackageReference Include="OwlCore.Kubo" Version="0.20.1" />
+    	<PackageReference Include="OwlCore.Nomad" Version="0.10.0" />
+		<PackageReference Include="PolySharp" Version="1.15.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\ocnomad\src\OwlCore.Nomad.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -24,11 +24,10 @@
 		<PackageReleaseNotes>
 --- 0.15.0 ---
 [Breaking]
-Removed SourceAddEvent and SourceRemoveEvent. The EventId for these are now hardcoded.
-The logic for NomadKuboEventStreamHandlerExtensions.ResolveEventStreamEntriesAsync has been updated. 
 Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore.Nomad.Storage 0.10.0.
+Existing event streams will need to be recreated or migrated to the new model changes. 
+Removed SourceAddEvent and SourceRemoveEvent. The EventId for these have changed and have been moved to a static ReservedEventIds class.
 All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.
-Existing event streams will need to be recreated or migrated to the new format. 
 
 --- 0.14.1 ---
 [Fixes]

--- a/src/ReservedEventIds.cs
+++ b/src/ReservedEventIds.cs
@@ -1,0 +1,24 @@
+/// <summary>
+/// This class contains all the reserved event ids that are used by the system.
+/// </summary>
+public static class ReservedEventIds
+{
+    /// <summary>
+    /// Returns all the reserved event ids.
+    /// </summary>
+    public static IEnumerable<string> GetAll()
+    {
+        yield return NomadEventStreamSourceAddEvent;
+        yield return NomadEventStreamSourceRemoveEvent;
+    }
+
+    /// <summary>
+    /// The event id for when a source is added.
+    /// </summary>
+    public const string NomadEventStreamSourceAddEvent = nameof(NomadEventStreamSourceAddEvent);
+
+    /// <summary>
+    /// The event id for when a source is removed.
+    /// </summary>
+    public const string NomadEventStreamSourceRemoveEvent = nameof(NomadEventStreamSourceRemoveEvent);
+}


### PR DESCRIPTION
[Breaking]
- Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0.
- Existing event streams will need to be recreated or migrated to the new model changes. 
- Removed SourceAddEvent and SourceRemoveEvent. The EventId for these have changed and have been moved to a static ReservedEventIds class.
- All code regarding Event Streams and Event Stream Entries have been updated to use DagCid instead of Cid. Cid can be a libp2p key, while a DagCid always links immutable data.
- The interface method INomadKuboEventStreamHandler.AppendNewEntryAsync has an update signature. The parameters were previously only TEventEntryContent and a CancellationToken, but are now a targetId, an eventId, TEventEntryContent, a timestampUtc and a cancellationToken in that order.
- The interface method INomadKuboEventStreamHandler.ApplyEntryUpdateAsync has an updated signature. The parameters were previously only TEventEntryContent and a CancellationToken, but are now an event stream entry, TEventEntryContent and a cancellationToken in that order.

[Improvement]
- The method NomadKuboEventStreamHandlerBase.AppendNewEntryAsync now has a default body as has been marked virtual. It no longer needs to be overriden in a derived class if the default behavior is desired.

Closes #6