### PR TITLE
Release 0.16.0

### DIFF
--- a/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
+++ b/src/Extensions/NomadKuboEventStreamHandlerExtensions.cs
@@ -270,11 +270,11 @@ public static class NomadKuboEventStreamHandlerExtensions
             foreach (var entry in eventStreamEntries)
             {
                 Guard.IsNotNull(entry.Value);
-                Guard.IsNotNullOrWhiteSpace(entry.Value.Content?.ToString());
+                Guard.IsNotNullOrWhiteSpace(entry.Value.Content.ToString());
                 Guard.IsNotNullOrWhiteSpace(entry.Value.EventId);
                 Guard.IsNotNullOrWhiteSpace(entry.Value.TargetId);
-
-                if (entry.Value.EventId != ReservedEventIds.NomadEventStreamSourceAddEvent && entry.Value.EventId != ReservedEventIds.NomadEventStreamSourceRemoveEvent)
+                
+                if(!ReservedEventIds.GetAll().Contains(entry.Value.EventId))
                     yield return entry.Value;
             }
         }

--- a/src/NomadKeyHelpers.cs
+++ b/src/NomadKeyHelpers.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.Diagnostics;
 using Ipfs;
-using Ipfs.CoreApi;
 
 namespace OwlCore.Nomad.Kubo;
 
@@ -15,30 +14,40 @@ public static class NomadKeyHelpers
     /// <param name="roamingId">The roaming ID of the item to retrieve. If this is null or is a value present in this node, a modifiable item will be returned.</param>
     /// <param name="roamingKeyName">The name of the roaming key to use if <paramref name="roamingId"/> is null.</param>
     /// <param name="localKeyName">The name of the local key to use if <paramref name="roamingId"/> is null.</param>
-    /// <param name="client">The client to use for communicating with IPFS.</param>
+    /// <param name="keys">The keys to check.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public static async Task<(IKey? LocalKey, IKey? RoamingKey, string? RoamingId)> RoamingIdToNomadKeysAsync(string? roamingId, string roamingKeyName, string localKeyName, ICoreApi client, CancellationToken cancellationToken)
+    public static async Task<(IKey? LocalKey, IKey? RoamingKey, string? RoamingId)> GetNomadKeysAsync(string? roamingId, string roamingKeyName, string localKeyName, IKey[] keys, CancellationToken cancellationToken)
     {
         IKey? roamingKey = null;
         IKey? localKey = null;
 
         // roamingId should be null to specify an object that hasn't been created.
         // Only load keys from this node if requested.
-        var keys = await client.Key.ListAsync(cancellationToken);
         var existingRoamingKey = keys.FirstOrDefault(x => $"{x.Id}" == $"{roamingId}");
 
-        if (roamingId is null || existingRoamingKey is not null)
-        {
-            // Get roaming id of this item.
-            roamingKey = existingRoamingKey ?? keys.FirstOrDefault(x => x.Name == roamingKeyName);
-            if (roamingKey is not null)
-            {
-                roamingId = roamingKey.Id;
-                localKey = keys.FirstOrDefault(x => x.Name == localKeyName);
-                return (localKey, roamingKey, roamingId);
-            }
-        }
+        // Read-only configuration.
+        // - Roaming key's ID is known (resolvable),
+        // - but the roaming key isn't accessible (publishable).
+        if (roamingId is not null && existingRoamingKey is null)
+            return (localKey, roamingKey, roamingId);
 
+        // Get roaming key via known key name if needed.
+        roamingKey = existingRoamingKey ?? keys.FirstOrDefault(x => x.Name == roamingKeyName);
+        
+        // "New key" modifiable configuration
+        // Roaming key cannot be found via roaming id or via roaming key name.
+        if (roamingKey is null)
+        {
+            // roamingId should also be null if it's a new key 
+            Guard.IsNull(roamingId);
+            return (localKey, roamingKey, roamingId);
+        }
+    
+        roamingId = roamingKey.Id;
+        localKey = keys.FirstOrDefault(x => x.Name == localKeyName);
+
+        // "Existing key" Modifiable configuration
+        // The roaming id and key both exist, changes can be published.
         return (localKey, roamingKey, roamingId);
     }
 }

--- a/src/NomadKuboEventStreamHandlerConfig.cs
+++ b/src/NomadKuboEventStreamHandlerConfig.cs
@@ -34,15 +34,35 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     public IKey? LocalKey { get; set; }
 
     /// <summary>
-    /// The key name used to publish the local event stream.
+    /// The key name used to create the local event stream key.
     /// </summary>
-    public required string LocalKeyName { get; set; }
+    public string? LocalKeyName { get; set; }
 
     /// <summary>
-    /// The key name used to published the roaming data.
+    /// The key name used to create the roaming data key.
     /// </summary>
-    public required string RoamingKeyName { get; set; }
+    public string? RoamingKeyName { get; set; }
 
+    /// <summary>
+    /// A boolean that represents whether the roaming value can be resolved (whether a roaming id is known) and whether it should be resolved (roaming value is not known).
+    /// </summary>
+    public bool CanAndShouldResolveRoamingValue => RoamingId is not null && RoamingValue is null;
+
+    /// <summary>
+    /// A boolean that indicates whether the local value can be resolved (whether a local key is known) and whether it should be resolved (local value is not known).
+    /// </summary>
+    public bool CanAndShouldResolveLocalValue => LocalKey is not null && LocalValue is null;
+    
+    /// <summary>
+    /// A boolean that indicates whether this object has a local key/value pair.
+    /// </summary>
+    public bool HasLocalKvp => LocalKey is not null && LocalValue is not null;
+  
+    /// <summary>
+    /// A boolean that indicates whether this config has local and roaming keys.
+    /// </summary>
+    public bool NoKeys => (LocalKey is null || RoamingKey is null) && (LocalKey is null == RoamingKey is null ? true : throw new InvalidOperationException("Either roaming or local key was null, but not both. This is an invalid configuration. Event stream handler configs and repositories are currently designed to have a 1:1 roaming/local KVP correspondence. See for details https://github.com/Arlodotexe/OwlCore.Nomad.Kubo/issues/8"));
+    
     /// <summary>
     /// Pre-resolved event stream entries for this handler. Optional.
     /// </summary>

--- a/src/NomadKuboRepository.cs
+++ b/src/NomadKuboRepository.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Diagnostics;
+using Ipfs;
 
 namespace OwlCore.Nomad.Kubo;
 
@@ -10,12 +11,83 @@ namespace OwlCore.Nomad.Kubo;
 /// <typeparam name="TRoaming">The published roaming value type.</typeparam>
 /// <typeparam name="TEventEntryContent">The base content type of the event stream entries.</typeparam>
 /// <typeparam name="TCreateParam"></typeparam>
-public abstract class NomadKuboRepository<TModifiable, TReadOnly, TRoaming, TEventEntryContent, TCreateParam> : NomadKuboRepositoryBase<TModifiable, TReadOnly, TReadOnly, TEventEntryContent>, INomadKuboRepository<TModifiable, TReadOnly, TCreateParam>
+public abstract class NomadKuboRepository<TModifiable, TReadOnly, TRoaming, TEventEntryContent, TCreateParam> : NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, TEventEntryContent>, INomadKuboRepository<TModifiable, TReadOnly, TCreateParam>
     where TReadOnly : notnull
     where TModifiable : TReadOnly, INomadKuboEventStreamHandler<TEventEntryContent>
 {
     /// <inheritdoc/>
-    public abstract Task<TModifiable> CreateAsync(TCreateParam createParam, CancellationToken cancellationToken);
+    public override event EventHandler<TReadOnly[]>? ItemsAdded;
+
+    /// <summary>
+    /// Gets a new set of local and roaming key names.
+    /// </summary>
+    public abstract (string LocalKeyName, string RoamingKeyName) GetNewKeyNames(TCreateParam createParam);
+
+    /// <summary>
+    /// Gets the initial event stream label used for a given set of newly created keys.
+    /// </summary>
+    public abstract string GetNewEventStreamLabel(TCreateParam createParam, IKey roamingKey, IKey localKey);
+
+    /// <summary>
+    /// Gets the initial roaming value for a given set of newly created keys.
+    /// </summary>
+    public abstract TRoaming GetInitialRoamingValue(TCreateParam createParam, IKey roamingKey, IKey localKey);
+    
+    /// <inheritdoc/>
+    public virtual async Task<TModifiable> CreateAsync(TCreateParam createParam, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var keyNames = GetNewKeyNames(createParam);
+        var existingConfig = ManagedConfigs.FirstOrDefault(x => x.LocalKeyName == keyNames.LocalKeyName && x.RoamingKeyName == keyNames.RoamingKeyName);
+        var config = existingConfig ?? GetEmptyConfig();
+        
+        config.LocalKeyName = keyNames.LocalKeyName;
+        config.RoamingKeyName = keyNames.RoamingKeyName;
+        config.LocalKey = ManagedKeys.FirstOrDefault(x => x.Name == keyNames.LocalKeyName);
+        config.RoamingKey = ManagedKeys.FirstOrDefault(x => x.Name == keyNames.RoamingKeyName);
+
+        // If local is null, roaming should be too, and vice versa
+        Guard.IsEqualTo(config.LocalKey is null, config.RoamingKey is null);
+
+        // Setup local and roaming data
+        var needsKeySetup = config.NoKeys;
+        if (needsKeySetup)
+        {
+            // Key doesn't exist, create it and return data.
+            var (local, roaming) = await NomadKeyGen.CreateAsync(keyNames.LocalKeyName, keyNames.RoamingKeyName, (l, r) => GetNewEventStreamLabel(createParam, r, l), (l, r) => GetInitialRoamingValue(createParam, r, l), Client, cancellationToken);
+            
+            // Data isn't published and won't resolve.
+            // The known default value must be passed around manually
+            // until it is ready to be published.
+            config.RoamingId = roaming.Key.Id;
+            config.LocalKey = local.Key;
+            config.RoamingKey = roaming.Key;
+            config.LocalValue = local.Value;
+            config.RoamingValue = roaming.Value;
+
+            // To avoid resolving the unpublished local ipns key, set the resolved entries to empty.
+            config.ResolvedEventStreamEntries = [];
+            
+            ManagedKeys.Add(local.Key);
+            ManagedKeys.Add(roaming.Key);
+            ManagedConfigs.Add(config);
+        }
+
+        Guard.IsNotNullOrWhiteSpace(config.RoamingId?.ToString());
+
+        // Created default or retrieved values are used.
+        // Reuse existing handler config instance (for new unpublished data)
+        var modifiable = (TModifiable)await GetAsync(config, cancellationToken);
+        
+        // Only raise collection modified if something new was set up
+        if (needsKeySetup)
+        {
+            ItemsAdded?.Invoke(this, [modifiable]);
+        }
+
+        return modifiable;
+    }
 }
 
 /// <summary>
@@ -25,45 +97,81 @@ public abstract class NomadKuboRepository<TModifiable, TReadOnly, TRoaming, TEve
 /// <typeparam name="TReadOnly">The type of item that can be read from this repository.</typeparam>
 /// <typeparam name="TRoaming">The published roaming value type.</typeparam>
 /// <typeparam name="TEventEntryContent">The base content type of the event stream entries.</typeparam>
-public class NomadKuboRepository<TModifiable, TReadOnly, TRoaming, TEventEntryContent> : NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, TEventEntryContent>, INomadKuboRepository<TModifiable, TReadOnly>
+public abstract class NomadKuboRepository<TModifiable, TReadOnly, TRoaming, TEventEntryContent> : NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, TEventEntryContent>, INomadKuboRepository<TModifiable, TReadOnly>
     where TReadOnly : notnull
     where TModifiable : TReadOnly, INomadKuboEventStreamHandler<TEventEntryContent>
 {
     /// <inheritdoc/>
+    public override event EventHandler<TReadOnly[]>? ItemsAdded;
+
+    /// <summary>
+    /// Gets a new set of local and roaming key names.
+    /// </summary>
+    public abstract (string LocalKeyName, string RoamingKeyName) GetNewKeyNames();
+
+    /// <summary>
+    /// Gets the initial event stream label used for a given set of newly created keys.
+    /// </summary>
+    public abstract string GetNewEventStreamLabel(IKey roamingKey, IKey localKey);
+
+    /// <summary>
+    /// Gets the initial roaming value for a given set of newly created keys.
+    /// </summary>
+    public abstract TRoaming GetInitialRoamingValue(IKey roamingKey, IKey localKey);
+
+    /// <inheritdoc/>
     public virtual async Task<TModifiable> CreateAsync(CancellationToken cancellationToken)
     {
-        var selfEventStreamHandlerConfig = await GetEventStreamHandlerConfigAsync(SelfRoamingId, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
+        var keyNames = GetNewKeyNames();
+        var existingConfig = ManagedConfigs.FirstOrDefault(x => x.LocalKeyName == keyNames.LocalKeyName && x.RoamingKeyName == keyNames.RoamingKeyName);
+        var config = existingConfig ?? GetEmptyConfig();
+
+        config.LocalKeyName = keyNames.LocalKeyName;
+        config.RoamingKeyName = keyNames.RoamingKeyName;
+        config.LocalKey = ManagedKeys.FirstOrDefault(x=> x.Name == keyNames.LocalKeyName);
+        config.RoamingKey = ManagedKeys.FirstOrDefault(x=> x.Name == keyNames.RoamingKeyName);
+        
         // If local is null, roaming should be too, and vice versa
-        Guard.IsEqualTo(selfEventStreamHandlerConfig.LocalKey is null, selfEventStreamHandlerConfig.RoamingKey is null);
+        Guard.IsEqualTo(config.LocalKey is null, config.RoamingKey is null);
 
         // Setup local and roaming data
-        var needsSetup = selfEventStreamHandlerConfig.LocalKey is null || selfEventStreamHandlerConfig.RoamingKey is null;
-        if (needsSetup)
+        var needsKeySetup = config.NoKeys;
+        if (needsKeySetup)
         {
             // Key doesn't exist, create it and return data.
+            var (local, roaming) = await NomadKeyGen.CreateAsync(keyNames.LocalKeyName, keyNames.RoamingKeyName, GetNewEventStreamLabel, GetInitialRoamingValue, Client, cancellationToken);
+
             // Data isn't published and won't resolve.
             // The known default value must be passed around manually
             // until it is ready to be published.
-            var (local, roaming) = await NomadKeyGen.CreateAsync(selfEventStreamHandlerConfig.LocalKeyName, selfEventStreamHandlerConfig.RoamingKeyName, eventStreamLabel: DefaultEventStreamLabel, GetDefaultRoamingValue, Client, cancellationToken);
-
-            SelfRoamingId = roaming.Key.Id;
-            selfEventStreamHandlerConfig.RoamingId = roaming.Key.Id;
-            selfEventStreamHandlerConfig.LocalKey = local.Key;
-            selfEventStreamHandlerConfig.RoamingKey = roaming.Key;
-            selfEventStreamHandlerConfig.LocalValue = local.Value;
-            selfEventStreamHandlerConfig.RoamingValue = roaming.Value;
+            config.RoamingId = roaming.Key.Id;
+            config.LocalKey = local.Key;
+            config.RoamingKey = roaming.Key;
+            config.LocalValue = local.Value;
+            config.RoamingValue = roaming.Value;
 
             // To avoid resolving an unpublished ipns key, set the resolved entries to empty.
-            selfEventStreamHandlerConfig.ResolvedEventStreamEntries = [];
+            config.ResolvedEventStreamEntries = [];
+            
+            ManagedKeys.Add(local.Key);
+            ManagedKeys.Add(roaming.Key);
+            ManagedConfigs.Add(config);
         }
 
-        Guard.IsNotNullOrWhiteSpace(selfEventStreamHandlerConfig.RoamingId?.ToString());
+        Guard.IsNotNullOrWhiteSpace(config.RoamingId?.ToString());
 
         // Created default or retrieved values are used.
         // Reuse existing handler config instance (for new unpublished data)
-        var modifiable = await GetAsync(selfEventStreamHandlerConfig, cancellationToken);
+        var modifiable = (TModifiable)await GetAsync(config, cancellationToken);
+        
+        // Only raise collection modified if something new was set up
+        if (needsKeySetup)
+        {
+            ItemsAdded?.Invoke(this, [modifiable]);
+        }
 
-        return (TModifiable)modifiable;
+        return modifiable;
     }
 }

--- a/src/NomadKuboRepositoryBase.cs
+++ b/src/NomadKuboRepositoryBase.cs
@@ -198,8 +198,8 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
         // If given roaming id isn't managed by this repo, construct a config using roaming id, key names (if any) and ManagedKeys.
         var config = await GetExistingConfigAsync(id, cancellationToken);
 
-        // Return read-only if keys aren't found.
         // Return modifiable if keys are found.
+        // Return read-only if keys aren't found.
         // Data should not be null when key is null (readonly)
         //  - Key should be null when the node is unpaired, which means to create a read-only instance.
         //  - Data must be supplied to create read-only instance, must be pre-populated.

--- a/src/NomadKuboRepositoryBase.cs
+++ b/src/NomadKuboRepositoryBase.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
+using OwlCore.Diagnostics;
 using OwlCore.Kubo;
 
 namespace OwlCore.Nomad.Kubo;
@@ -17,51 +18,88 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
     /// The IPFS client used to interact with the network.
     /// </summary>
     public required ICoreApi Client { get; init; }
-    
+
     /// <summary>
     /// Various options to use when interacting with Kubo's API.
     /// </summary>
     public required IKuboOptions KuboOptions { get; init; }
 
     /// <summary>
-    /// The ID of the event stream handler that represents this node.
+    /// The config objects for event stream handlers whose lifecycles are managed by this repository.
+    /// </summary>
+    public ICollection<NomadKuboEventStreamHandlerConfig<TRoaming>> ManagedConfigs { get; protected set; } = [];
+
+    /// <summary>
+    /// The keys that this node operator has access to.
+    /// </summary>
+    public required ICollection<IKey> ManagedKeys { get; init; } = new List<IKey>();
+
+    /// <summary>
+    /// Creates a new empty instance of <see cref="NomadKuboEventStreamHandlerConfig{TRoaming}"/> to use or manage in this repository.
+    /// </summary>
+    protected abstract NomadKuboEventStreamHandlerConfig<TRoaming> GetEmptyConfig();
+
+    /// <summary>
+    /// Gets an event stream handler config used to construct existing ReadOnly (managed by another repository or node operator) and existing Modifiable (lifecycle managed by this repository or node operator) event stream handlers. New Modifiable configurations are not handled here.
     /// </summary>
     /// <remarks>
-    /// There can be only one 'self' event stream handler config for an item, even in a repository.
+    /// If local and roaming keys are returned, it can be used to create a modifiable event stream handler.
+    /// <para/>
+    /// If no local and roaming keys are returned but a roaming ID is, it can be used to create read-only instance.
     /// </remarks>
-    public string? SelfRoamingId { get; protected set; }
+    /// <param name="roamingId">A unique identifier for the roaming data.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the event stream handler configuration.</returns>
+    public virtual async Task<NomadKuboEventStreamHandlerConfig<TRoaming>> GetExistingConfigAsync(string roamingId, CancellationToken cancellationToken)
+    {
+        var keyNames = await GetExistingKeyNamesAsync(roamingId, cancellationToken);
+        keyNames ??= (string.Empty, string.Empty);
+        
+        // The GetNomadKeysAsync helper method does three things:
+        // ------------------------------------
+        // Finds roaming key by a given roaming key id
+        // Finds both roaming key and roaming key id by a given roaming key name
+        // Finds local key by a given local key name
+        // ------------------------------------
+        // Handles all three possible configuration:
+        // - Existing readonly (has roamingId but not roaming key)
+        // - Existing modifiable (has roamingId and roaming Key)
+        // - New modifiable (unused at this call site)
+        // ------------------------------------
+        var (localKey, roamingKey, foundRoamingId) = await NomadKeyHelpers.GetNomadKeysAsync(roamingId, keyNames.Value.RoamingKeyName, keyNames.Value.LocalKeyName, ManagedKeys.ToArray(), cancellationToken);
+
+        var config = GetEmptyConfig();
+        config.RoamingId = roamingKey?.Id ?? (foundRoamingId is not null ? Cid.Decode(foundRoamingId) : null);
+        config.RoamingKey = roamingKey;
+        config.RoamingKeyName = roamingKey?.Name;
+        config.LocalKey = localKey;
+        config.LocalKeyName = localKey?.Name;
+        return config;
+    }
 
     /// <summary>
-    /// A delegate that gets a config used to construct an event stream handler given an arbitrary id.
+    /// Returns the known local and roaming key names for the provided roaming ID.
     /// </summary>
-    public required GetEventStreamHandlerConfigAsyncDelegate<TRoaming> GetEventStreamHandlerConfigAsync { get; set; }
+    /// <param name="roamingId">The ID of the roaming key to retrieve the local and roaming key names of.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    public abstract Task<(string LocalKeyName, string RoamingKeyName)?> GetExistingKeyNamesAsync(string roamingId, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Constructs a read-only instance from a handler configuration.
+    /// </summary>
+    public abstract TReadOnly ReadOnlyFromHandlerConfig(NomadKuboEventStreamHandlerConfig<TRoaming> handlerConfig);
 
     /// <summary>
-    /// A delegate that gets the default roaming value for an item.
+    /// Constructs a modifiable instance from a handler configuration.
     /// </summary>
-    public required Func<IKey, IKey, TRoaming> GetDefaultRoamingValue { get; set; }
-
-    /// <summary>
-    /// The default event stream label.
-    /// </summary>
-    public required string DefaultEventStreamLabel { get; set; }
-
-    /// <summary>
-    /// A delegate that constructs a read-only instance from a handler configuration.
-    /// </summary>
-    public required ReadOnlyFromHandlerConfigDelegate<TReadOnly, TRoaming> ReadOnlyFromHandlerConfig { get; set; }
-
-    /// <summary>
-    /// A delegate that constructs a modifiable instance from a handler configuration.
-    /// </summary>
-    public required ModifiableFromHandlerConfigDelegate<TModifiable, TRoaming> ModifiableFromHandlerConfig { get; set; }
-
+    public abstract TModifiable ModifiableFromHandlerConfig(NomadKuboEventStreamHandlerConfig<TRoaming> handlerConfig);
+    
     /// <inheritdoc/>
     public virtual event EventHandler<TReadOnly[]>? ItemsAdded;
 
     /// <inheritdoc/>
     public virtual event EventHandler<TReadOnly[]>? ItemsRemoved;
-    
+
     /// <summary>
     /// Retrieves the items in the registry.
     /// </summary>
@@ -70,48 +108,58 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
     /// <returns>An async enumerable containing the items in the registry.</returns>
     public virtual async Task<TReadOnly> GetAsync(NomadKuboEventStreamHandlerConfig<TRoaming> config, CancellationToken cancellationToken)
     {
-        if (config.RoamingValue is null && config.RoamingId is not null)
+        cancellationToken.ThrowIfCancellationRequested();
+        
+        // Resolve roaming value if needed.
+        // If roaming value is missing but the key is not, it may be published
+        // Roaming value should always be provided on creation (when unpublished)
+        if (config.CanAndShouldResolveRoamingValue)
         {
-            // Roaming value should always be provided on creation (when unpublished)
-            // If roaming value is missing but the key is not, it may be published
-            // Resolve roaming value if needed.
-            var (resolvedRoaming, _) = await Client.ResolveDagCidAsync<TRoaming>(config.RoamingId, nocache: !KuboOptions.UseCache, cancellationToken);
-            config.RoamingValue = resolvedRoaming;
+            Guard.IsNotNull(config.RoamingId);
+            var (resolvedRoamingValue, _) = await Client.ResolveDagCidAsync<TRoaming>(config.RoamingId, nocache: !KuboOptions.UseCache, cancellationToken);
+            config.RoamingValue = resolvedRoamingValue;
 
             // In this state, the local value may also be missing but resolvable.
             // Resolve local value if needed.
-            if (config.LocalValue is null && config.LocalKey is not null)
+            if (config.CanAndShouldResolveLocalValue)
             {
-                var (resolvedLocal, _) = await Client.ResolveDagCidAsync<EventStream<DagCid>>(config.LocalKey.Id, nocache: !KuboOptions.UseCache, cancellationToken);
-                config.LocalValue = resolvedLocal;
+                Guard.IsNotNull(config.LocalKey);
+                var (resolvedLocalEventStream, _) = await Client.ResolveDagCidAsync<EventStream<DagCid>>(config.LocalKey.Id, nocache: !KuboOptions.UseCache, cancellationToken);
+                config.LocalValue = resolvedLocalEventStream;
             }
         }
-        
-        if (config.LocalValue is null || config.LocalKey is null)
+
+        // If the local event stream key/value pair are missing, assume readonly.
+        // Otherwise, assume modifiable.
+        if (!config.HasLocalKvp)
         {
             // An "in-memory" state is required at the callsite where ReadOnly is constructed.
             Guard.IsNotNull(config.RoamingValue);
             Guard.IsNotNull(config.RoamingId);
+            
             return ReadOnlyFromHandlerConfig(config);
         }
-        
+
         // Resolved entries list must be initialized before instantiating handlers.
-        // Allows handlers to reference the list when populated here.
+        // Allows handlers to reference the list that we populate below.
         var resolvedEntriesWasNull = config.ResolvedEventStreamEntries is null;
         config.ResolvedEventStreamEntries ??= [];
 
         // Return modifiable if keys are present.
         // Key should not be null when data is null.
-        //  - When data is null, it implies that either it hasn't been published or isn't needed yet, both of which are only possible for a modifiable instance.
+        //  - When data is null, it implies that either it hasn't been published or isn't needed yet, both of which are only possible for a modifiable instance (meaning a key should be present)
         //    - Initial data isn't always required since we can start from a seed state and advance the event stream handler.
         //    - Initial data may be desired anyway when:
-        //      - Advancing from a checkpoint, especially the last known roaming state.
+        //      - Advancing from a checkpoint, especially the last known roaming state (e.g. live updates)
         //      - Using all published sources (including the original source node) instead of just the sources paired to you.
         var modifiable = ModifiableFromHandlerConfig(config);
         if (resolvedEntriesWasNull)
         {
             // Resolve entries and advance event stream.
-            await foreach (var entry in modifiable.ResolveEventStreamEntriesAsync(cancellationToken))
+            await foreach (var entry in modifiable.ResolveEventStreamEntriesAsync(cancellationToken)
+                               .Where(x => (x.TimestampUtc ?? ThrowHelper.ThrowArgumentNullException<DateTime>()) <= DateTime.UtcNow)
+                               .OrderBy(x => x.TimestampUtc)
+                               .WithCancellation(cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -123,7 +171,9 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
         }
         else
         {
-            foreach (var entry in config.ResolvedEventStreamEntries)
+            foreach (var entry in config.ResolvedEventStreamEntries
+                         .Where(x => (x.TimestampUtc ?? ThrowHelper.ThrowArgumentNullException<DateTime>()) <= DateTime.UtcNow)
+                         .OrderBy(x => x.TimestampUtc))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -138,62 +188,61 @@ public abstract class NomadKuboRepositoryBase<TModifiable, TReadOnly, TRoaming, 
     /// <inheritdoc/>
     public virtual async Task<TReadOnly> GetAsync(string id, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Iterate through the managed configs to find the one with the specified roaming ID.
+        var existingManagedConfig = ManagedConfigs.FirstOrDefault(x => x.RoamingId == id);
+        if (existingManagedConfig is not null)
+            return await GetAsync(existingManagedConfig, cancellationToken);
+
+        // If given roaming id isn't managed by this repo, construct a config using roaming id, key names (if any) and ManagedKeys.
+        var config = await GetExistingConfigAsync(id, cancellationToken);
+
         // Return read-only if keys aren't found.
-        // Data should not be null when key is null
+        // Return modifiable if keys are found.
+        // Data should not be null when key is null (readonly)
         //  - Key should be null when the node is unpaired, which means to create a read-only instance.
         //  - Data must be supplied to create read-only instance, must be pre-populated.
-        var config = await GetEventStreamHandlerConfigAsync(id, cancellationToken);
         return await GetAsync(config, cancellationToken);
     }
 
     /// <inheritdoc/>
     public virtual async IAsyncEnumerable<TReadOnly> GetAsync([EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var selfEventStreamHandlerConfig = await GetEventStreamHandlerConfigAsync(SelfRoamingId, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        // List all items stored in this Kubo repo
-        // Only yields the item that represents this node.
-        // There is only one known in this context, can be overriden in base class.
-        if (selfEventStreamHandlerConfig.RoamingId is not null)
-            yield return await GetAsync(selfEventStreamHandlerConfig, cancellationToken);
+        foreach (var managedConfig in ManagedConfigs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Logger.LogInformation($"Getting event stream handler for roaming key {managedConfig}.");
+
+            // Get the roaming id for this node.
+            Guard.IsNotNull(managedConfig.RoamingId);
+            yield return await GetAsync(managedConfig, cancellationToken);
+        }
     }
 
     /// <inheritdoc/>
     public virtual async Task DeleteAsync(TModifiable item, CancellationToken cancellationToken)
     {
-        var selfEventStreamHandlerConfig = await GetEventStreamHandlerConfigAsync(SelfRoamingId, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        if (item.EventStreamHandlerId != selfEventStreamHandlerConfig.RoamingId)
-            throw new ArgumentException($"The provided {nameof(item.EventStreamHandlerId)} does not match the {nameof(SelfRoamingId)} for this repository. Only the roaming id that represents this node can be deleted.");
+        var existingManagedConfig = ManagedConfigs.FirstOrDefault(x => x.RoamingId == item.EventStreamHandlerId);
+        if (existingManagedConfig is null)
+            throw new InvalidOperationException($"The item with {nameof(item.EventStreamHandlerId)} {item.EventStreamHandlerId} does not exist in this repository.");
 
+        var config = await GetExistingConfigAsync(item.EventStreamHandlerId, cancellationToken);
+        Guard.IsEqualTo(item.EventStreamHandlerId, config.RoamingId?.ToString() ?? string.Empty);
+
+        Guard.IsNotNull(config.RoamingKeyName);
+        Guard.IsNotNull(config.LocalKeyName);
+        Logger.LogInformation($"Deleting roaming key {config.RoamingKeyName} and local key {config.LocalKeyName}.");
+        
         // Delete the roaming and local keys
-        await Client.Key.RemoveAsync(selfEventStreamHandlerConfig.RoamingKeyName, cancellationToken);
-        await Client.Key.RemoveAsync(selfEventStreamHandlerConfig.LocalKeyName, cancellationToken);
+        await Client.Key.RemoveAsync(config.RoamingKeyName, cancellationToken);
+        await Client.Key.RemoveAsync(config.LocalKeyName, cancellationToken);
+        
+        ManagedConfigs.Remove(existingManagedConfig);
+        ItemsRemoved?.Invoke(this, [item]);
     }
 }
-
-/// <summary>
-/// A delegate that gets a configuration used to construct an event stream handler given an arbitrary ID.
-/// </summary>
-/// <typeparam name="TRoaming">The published roaming value type.</typeparam>
-/// <param name="roamingId">A unique identifier for the roaming data. A null value represents an object yet to be created.</param>
-/// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-/// <returns>A task that represents the asynchronous operation. The task result contains the event stream handler configuration.</returns>
-public delegate Task<NomadKuboEventStreamHandlerConfig<TRoaming>> GetEventStreamHandlerConfigAsyncDelegate<TRoaming>(string? roamingId, CancellationToken cancellationToken);
-
-/// <summary>
-/// A delegate that constructs a read-only instance from a handler configuration.
-/// </summary>
-/// <param name="handlerConfig">The handler configuration to use.</param>
-/// <returns>A new instance of the read-only type.</returns>
-public delegate TReadOnly ReadOnlyFromHandlerConfigDelegate<out TReadOnly, TRoaming>(NomadKuboEventStreamHandlerConfig<TRoaming> handlerConfig);
-
-/// <summary>
-/// A delegate that constructs a modifiable instance from a handler configuration.
-/// </summary>
-/// <typeparam name="TModifiable">The type of the result.</typeparam>
-/// <typeparam name="TRoaming">The published roaming value type.</typeparam>
-/// <param name="handlerConfig">The handler configuration to use.</param>
-/// <returns>A new instance of the modifiable type.</returns>
-public delegate TModifiable ModifiableFromHandlerConfigDelegate<out TModifiable, TRoaming>(NomadKuboEventStreamHandlerConfig<TRoaming> handlerConfig)
-    where TModifiable : IEventStreamHandler<DagCid, Cid, EventStream<DagCid>, EventStreamEntry<DagCid>>;

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -15,13 +15,46 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.15.1</Version>
+		<Version>0.16.0</Version>
 		<Product>OwlCore</Product>
 		<Description>Build a modifiable application domain across Kubo peers with eventual consistency. Cover the gap between "User device" and "User".</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.16.0 ---
+[Fixes]
+Fixed an issue where getting items via NomadKuboRepositoryBase.GetAsync(config) wouldn't order timestamps correctly before applying events, leading to invalid states in some cases where multiple devices are paired.
+
+[Breaking]
+NomadKeyHelpers.RoamingIdToNomadKeysAsync was renamed to NomadKeyHelpers.GetNomadKeysAsync.
+NomadKeyHelpers.GetNomadKeysAsync now takes a list of IKey instead of a Client to resolve them from.
+The third parameter of the NomadKeyGen.CreateAsync{TRoaming} method was changed from a string eventStreamLabel to a Func{IKey, IKey, string} getEventStreamLabel. This allows the event stream label to be generated based on the roaming and local keys, instead of being a static string.
+NomadKuboRepositoryBase now takes a collection of ManagedKeys instead of resolving them from the client.
+NomadKuboRepositoryBase now uses a collection of ManagedConfigs instead of a single SelfRoamingId property.
+NomadKuboRepositoryBase has a new abstract method GetExistingKeyNamesAsync that must be implemented by derived classes.
+The ReadOnlyFromHandlerConfig.ReadOnlyFromHandlerConfig delegate was superseded by an abstract method.
+The ModifiableFromHandlerConfig.ModifiableFromHandlerConfig delegate was superseded by an abstract method.
+NomadKuboRepository{TModifiable, TReadOnly, TRoaming, TEventEntryContent} is now an abstract class.
+NomadKuboRepository{TModifiable, TReadOnly, TRoaming, TEventEntryContent, TCreateParam} now implements CreateAsync in the base class.
+NomadKuboRepository.GetNewKeyNames was added as an abstract method that must be implemented by derived classes.
+NomadKuboRepository.GetNewEventStreamLabel was added as an abstract method that must be implemented by derived classes.
+NomadKuboRepository.GetInitialRoamingValue was added as an abstract method that must be implemented by derived classes.
+
+[Improvements]
+KeyExchange.PairWithEncryptedPubSubAsync now returns a tuple with a nullable SourceAddEventEntry and a nullable ImportedRoamingKvp tuple.
+KeyExchange.ExchangeRoamingKeyAsync now returns a nullable tuple with the received IPNS Key Cid and resolved ipns value CID. 
+KeyExchange.ExchangeLocalSourceAsync now returns a nullable EventStreamEntry{DagCid} with the new SourceAddEventEntry for the new received local source.
+KeyExchange.ReceiveLocalKeyAsync now returns EventStreamEntry{DagCid} with the new SourceAddEventEntry for the new received local source.
+KeyExchange.ReceiveRoamingKeyAsync now returns a tuple with the received IPNS Key Cid and resolved ipns value CID.
+
+[New]
+A get-only property NomadKuboEventStreamHandlerConfig{TRoaming}.CanAndShouldResolveRoamingValue was added.
+A get-only property NomadKuboEventStreamHandlerConfig{TRoaming}.CanAndShouldResolveLocalValue was added.
+A get-only property NomadKuboEventStreamHandlerConfig{TRoaming}.HasLocalKvp was added.
+A get-only property NomadKuboEventStreamHandlerConfig{TRoaming}.NoKeys was added.
+NomadKuboRepositoryBase.GetExistingConfigAsync was added and is implemented in the base class with code that was previously required as a delegate property.
+
 --- 0.15.1 ---
 [Improvements]
 Added supports for net8.0 and net9.0 in addition to netstandard2.0.
@@ -212,7 +245,7 @@ Initial release of OwlCore.Nomad.Kubo.
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
-		<PackageReference Include="OwlCore.Kubo" Version="0.20.1" />
+		<PackageReference Include="OwlCore.Kubo" Version="0.20.2" />
     	<PackageReference Include="OwlCore.Nomad" Version="0.10.1" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 		  <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
[Fixes]
Fixed an issue where getting items via NomadKuboRepositoryBase.GetAsync(config) wouldn't order timestamps correctly before applying events, leading to invalid states in some cases where multiple devices are paired.

[Breaking]
NomadKeyHelpers.RoamingIdToNomadKeysAsync was renamed to NomadKeyHelpers.GetNomadKeysAsync.
NomadKeyHelpers.GetNomadKeysAsync now takes a list of IKey instead of a Client to resolve them from.
The third parameter of the NomadKeyGen.CreateAsync{TRoaming} method was changed from a string eventStreamLabel to a Func<IKey, IKey, string> getEventStreamLabel. This allows the event stream label to be generated based on the roaming and local keys, instead of being a static string.
NomadKuboRepositoryBase now takes a collection of ManagedKeys instead of resolving them from the client.
NomadKuboRepositoryBase now uses a collection of ManagedConfigs instead of a single SelfRoamingId property.
NomadKuboRepositoryBase has a new abstract method GetExistingKeyNamesAsync that must be implemented by derived classes.
The ReadOnlyFromHandlerConfig.ReadOnlyFromHandlerConfig delegate was superseded by an abstract method.
The ModifiableFromHandlerConfig.ModifiableFromHandlerConfig delegate was superseded by an abstract method.
NomadKuboRepository{TModifiable, TReadOnly, TRoaming, TEventEntryContent} is now an abstract class.
NomadKuboRepository{TModifiable, TReadOnly, TRoaming, TEventEntryContent, TCreateParam} now implements CreateAsync in the base class.
NomadKuboRepository.GetNewKeyNames was added as an abstract method that must be implemented by derived classes.
NomadKuboRepository.GetNewEventStreamLabel was added as an abstract method that must be implemented by derived classes.
NomadKuboRepository.GetInitialRoamingValue was added as an abstract method that must be implemented by derived classes.

[Improvements]
KeyExchange.PairWithEncryptedPubSubAsync now returns a tuple with a nullable SourceAddEventEntry and a nullable ImportedRoamingKvp tuple.
KeyExchange.ExchangeRoamingKeyAsync now returns a nullable tuple with the received IPNS Key Cid and resolved ipns value CID.
KeyExchange.ExchangeLocalSourceAsync now returns a nullable EventStreamEntry<DagCid> with the new SourceAddEventEntry for the new received local source.
KeyExchange.ReceiveLocalKeyAsync now returns EventStreamEntry<DagCid> with the new SourceAddEventEntry for the new received local source.
KeyExchange.ReceiveRoamingKeyAsync now returns a tuple with the received IPNS Key Cid and resolved ipns value CID.

[New]
A get-only property NomadKuboEventStreamHandlerConfig<TRoaming>.CanAndShouldResolveRoamingValue was added.
A get-only property NomadKuboEventStreamHandlerConfig<TRoaming>.CanAndShouldResolveLocalValue was added.
A get-only property NomadKuboEventStreamHandlerConfig<TRoaming>.HasLocalKvp was added.
A get-only property NomadKuboEventStreamHandlerConfig<TRoaming>.NoKeys was added.
NomadKuboRepositoryBase.GetExistingConfigAsync was added and is implemented in the base class with code that was previously required as a delegate property.