### PR TITLE
Release 0.17.0. See package release note or expand full commit message.

### DIFF
--- a/src/NomadKuboEventStreamHandlerConfig.cs
+++ b/src/NomadKuboEventStreamHandlerConfig.cs
@@ -1,4 +1,7 @@
 using Ipfs;
+using Newtonsoft.Json;
+using OwlCore.ComponentModel;
+using OwlCore.Kubo;
 
 namespace OwlCore.Nomad.Kubo;
 
@@ -6,7 +9,7 @@ namespace OwlCore.Nomad.Kubo;
 /// Represents the configuration needed to construct either a read-only or modifiable event stream handler.
 /// </summary>
 /// <typeparam name="TRoaming">The published roaming value type.</typeparam>
-public record NomadKuboEventStreamHandlerConfig<TRoaming>
+public record NomadKuboEventStreamHandlerConfig<TRoaming> : ISources<Cid>
 {
     /// <summary>
     /// The ID of the roaming data.
@@ -16,6 +19,10 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     /// <summary>
     /// The value of the roaming data.
     /// </summary>
+    /// <remarks>
+    /// If this value is set when an event stream handler is created, it will be used as the initial value for the roaming data.
+    /// Any event stream entries that are applied to the event stream will be applied starting from this value.
+    /// </remarks>
     public TRoaming? RoamingValue { get; set; }
 
     /// <summary>
@@ -26,12 +33,12 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     /// <summary>
     /// The key used to publish the roaming data.
     /// </summary>
-    public IKey? RoamingKey { get; set; }
+    public Key? RoamingKey { get; set; }
 
     /// <summary>
     /// The key used to publish the local event stream.
     /// </summary>
-    public IKey? LocalKey { get; set; }
+    public Key? LocalKey { get; set; }
 
     /// <summary>
     /// The key name used to create the local event stream key.
@@ -46,28 +53,43 @@ public record NomadKuboEventStreamHandlerConfig<TRoaming>
     /// <summary>
     /// A boolean that represents whether the roaming value can be resolved (whether a roaming id is known) and whether it should be resolved (roaming value is not known).
     /// </summary>
+    [JsonIgnore]
     public bool CanAndShouldResolveRoamingValue => RoamingId is not null && RoamingValue is null;
 
     /// <summary>
     /// A boolean that indicates whether the local value can be resolved (whether a local key is known) and whether it should be resolved (local value is not known).
     /// </summary>
+    [JsonIgnore]
     public bool CanAndShouldResolveLocalValue => LocalKey is not null && LocalValue is null;
-    
+
     /// <summary>
     /// A boolean that indicates whether this object has a local key/value pair.
     /// </summary>
+    [JsonIgnore]
     public bool HasLocalKvp => LocalKey is not null && LocalValue is not null;
-  
+
     /// <summary>
     /// A boolean that indicates whether this config has local and roaming keys.
     /// </summary>
+    [JsonIgnore]
     public bool NoKeys => (LocalKey is null || RoamingKey is null) && (LocalKey is null == RoamingKey is null ? true : throw new InvalidOperationException("Either roaming or local key was null, but not both. This is an invalid configuration. Event stream handler configs and repositories are currently designed to have a 1:1 roaming/local KVP correspondence. See for details https://github.com/Arlodotexe/OwlCore.Nomad.Kubo/issues/8"));
-    
+
     /// <summary>
     /// Pre-resolved event stream entries for this handler. Optional.
     /// </summary>
     /// <remarks>
     /// A null value indicates the event stream entries have not been resolved.
+    /// <para/>
+    /// This is for runtime use by <see cref="NomadKuboRepository{TModifiable, TReadOnly, TRoaming, TEventEntryContent, TCreateParam}"/>. An assigned value indicates resolved entries for ALL sources, not just the local event stream. 
+    /// <para/>
+    /// If setting this property, ensure that you also resolve remote event stream entries for non-local sources, as this property is used to determine the full set of event stream entries for the handler. 
+    /// <para/>
+    /// If you do not set this property, it will be resolved automatically when needed.
     /// </remarks>
     public ICollection<EventStreamEntry<DagCid>>? ResolvedEventStreamEntries { get; set; }
+
+    /// <summary>
+    /// A collection of all local event stream sources that this handler is paired with.
+    /// </summary>
+    public ICollection<Cid> Sources { get; init; } = new List<Cid>();
 }

--- a/src/OwlCore.Nomad.Kubo.csproj
+++ b/src/OwlCore.Nomad.Kubo.csproj
@@ -15,13 +15,30 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.16.0</Version>
+		<Version>0.17.0</Version>
 		<Product>OwlCore</Product>
 		<Description>Build a modifiable application domain across Kubo peers with eventual consistency. Cover the gap between "User device" and "User".</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.17.0 ---
+[Breaking]
+NomadKuboRepositoryBase.ManagedConfigs is now a required property.
+NomadKuboRepositoryBase.ManagedKeys is now of type ICollection{OwlCore.Kubo.Key} instead of ICollection{Ipfs.IKey}.
+NomadKuboEventStreamHandlerConfig{TRoaming}.RoamingKey is now of type OwlCore.Kubo.Key instead of Ipfs.IKey.
+NomadKuboEventStreamHandlerConfig{TRoaming}.LocalKey is now of type OwlCore.Kubo.Key instead of Ipfs.IKey.
+
+[Improvements]
+NomadKuboEventStreamHandlerConfig is now fully serializable and deserializable via Newtonsoft.Json, allowing it to be directly used to store and load the data managed by a repository.
+OwlCore.Diagnostics trace logging has been added to NomadKuboRepositoryBase for various methods.
+NomadKuboRepositoryBase.GetAsync now internally resolves the local value independently of whether the roaming value was resolved.
+
+[New]
+NomadKuboRepositoryBase (and subsequently NomadKuboRepository) now has an InstanceCache property. When assigned, this is used to store and resolve already instantiated event stream handlers. This is required for event stream handlers that mutually reference each other in their event stream and also emit those instances while the event stream is advancing. 
+Added NomadKuboEventStreamHandlerConfig{TRoaming}.Sources. Previously, sources were stored and read from the RoamingValue, but this has been separated out to improve data handling at the repository level. Event stream handlers should be given a reference to this list of sources, rather than from the roaming value.
+NomadKuboEventStreamHandlerExtensions.ResolveEventStreamEntriesAsync now has a guard throw to ensure the provided sources on the event stream handler isn't empty. A modifiable event stream should always have at least a local source, even the source has no entries yet.
+
 --- 0.16.0 ---
 [Fixes]
 Fixed an issue where getting items via NomadKuboRepositoryBase.GetAsync(config) wouldn't order timestamps correctly before applying events, leading to invalid states in some cases where multiple devices are paired.
@@ -245,7 +262,7 @@ Initial release of OwlCore.Nomad.Kubo.
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Diagnostics" Version="0.0.0" />
-		<PackageReference Include="OwlCore.Kubo" Version="0.20.2" />
+		<PackageReference Include="OwlCore.Kubo" Version="0.21.0" />
     	<PackageReference Include="OwlCore.Nomad" Version="0.10.1" />
 		<PackageReference Include="PolySharp" Version="1.15.0">
 		  <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
[Breaking]
NomadKuboRepositoryBase.ManagedConfigs is now a required property.
NomadKuboRepositoryBase.ManagedKeys is now of type ICollection{OwlCore.Kubo.Key} instead of ICollection{Ipfs.IKey}.
NomadKuboEventStreamHandlerConfig{TRoaming}.RoamingKey is now of type OwlCore.Kubo.Key instead of Ipfs.IKey.
NomadKuboEventStreamHandlerConfig{TRoaming}.LocalKey is now of type OwlCore.Kubo.Key instead of Ipfs.IKey.

[Improvements]
NomadKuboEventStreamHandlerConfig is now fully serializable and deserializable via Newtonsoft.Json, allowing it to be directly used to store and load the data managed by a repository.
OwlCore.Diagnostics trace logging has been added to NomadKuboRepositoryBase for various methods.
NomadKuboRepositoryBase.GetAsync now internally resolves the local value independently of whether the roaming value was resolved.

[New]
NomadKuboRepositoryBase (and subsequently NomadKuboRepository) now has an InstanceCache property. When assigned, this is used to store and resolve already instantiated event stream handlers. This is required for event stream handlers that mutually reference each other in their event stream and also emit those instances while the event stream is advancing.
Added NomadKuboEventStreamHandlerConfig{TRoaming}.Sources. Previously, sources were stored and read from the RoamingValue, but this has been separated out to improve data handling at the repository level. Event stream handlers should be given a reference to this list of sources, rather than from the roaming value.
NomadKuboEventStreamHandlerExtensions.ResolveEventStreamEntriesAsync now has a guard throw to ensure the provided sources on the event stream handler isn't empty. A modifiable event stream should always have at least a local source, even the source has no entries yet.